### PR TITLE
Add tables of contents and auto-linked headings

### DIFF
--- a/next-js/next.config.js
+++ b/next-js/next.config.js
@@ -1,5 +1,12 @@
+const collapse = require('remark-collapse');
 const withMDX = require('@next/mdx')({
   extension: /\.mdx?$/,
+  options: {
+    remarkPlugins: [
+      [collapse, { test: '' }],
+    ],
+  },
+  rehypePlugins: [],
 });
 module.exports = withMDX({
   pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'md', 'mdx'],

--- a/next-js/next.config.js
+++ b/next-js/next.config.js
@@ -1,6 +1,7 @@
 const autolinkHeadings = require('remark-autolink-headings');
 const collapse = require('remark-collapse');
 const slug = require('remark-slug');
+const toc = require('remark-toc');
 
 const autoLinkHeadingsOptions = {
   behavior: 'prepend',
@@ -38,6 +39,7 @@ const withMDX = require('@next/mdx')({
       [collapse, { test: '' }],
       slug,
       [autolinkHeadings, autoLinkHeadingsOptions],
+      toc,
     ],
   },
   rehypePlugins: [],

--- a/next-js/next.config.js
+++ b/next-js/next.config.js
@@ -1,9 +1,43 @@
+const autolinkHeadings = require('remark-autolink-headings');
 const collapse = require('remark-collapse');
+const slug = require('remark-slug');
+
+const autoLinkHeadingsOptions = {
+  behavior: 'prepend',
+  linkProperties: {
+    className: ['anchor-link'],
+  },
+  content: {
+    type: 'element',
+    tagName: 'svg',
+    properties: {
+      xmlns: 'http://www.w3.org/2000/svg',
+      viewBox: '0 0 16 16',
+      width: '1rem',
+      height: '1rem',
+    },
+    children: [
+      {
+        type: 'element',
+        tagName: 'path',
+        properties: {
+          fillRule: 'evenodd',
+          d:
+            'M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z',
+        },
+        children: [],
+      },
+    ],
+  },
+};
+
 const withMDX = require('@next/mdx')({
   extension: /\.mdx?$/,
   options: {
     remarkPlugins: [
       [collapse, { test: '' }],
+      slug,
+      [autolinkHeadings, autoLinkHeadingsOptions],
     ],
   },
   rehypePlugins: [],

--- a/next-js/package-lock.json
+++ b/next-js/package-lock.json
@@ -2266,6 +2266,27 @@
       "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-1.1.0.tgz",
       "integrity": "sha512-jVU0Nr2B9X3MU4tSK7JP1CMkSvOj7X5l/GboG1tKRw52lLF1x2Ju92Ms9tNetCcbfX3hzlM73zYo2NKkWSfF/A=="
     },
+    "mdast-util-toc": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-toc/-/mdast-util-toc-5.1.0.tgz",
+      "integrity": "sha512-csimbRIVkiqc+PpFeKDGQ/Ck2N4f9FYH3zzBMMJzcxoKL8m+cM0n94xXm0I9eaxHnKdY9n145SGTdyJC7i273g==",
+      "requires": {
+        "@types/mdast": "^3.0.3",
+        "@types/unist": "^2.0.3",
+        "extend": "^3.0.2",
+        "github-slugger": "^1.2.1",
+        "mdast-util-to-string": "^2.0.0",
+        "unist-util-is": "^4.0.0",
+        "unist-util-visit": "^2.0.0"
+      },
+      "dependencies": {
+        "mdast-util-to-string": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
+          "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w=="
+        }
+      }
+    },
     "mdurl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
@@ -3006,6 +3027,15 @@
       "integrity": "sha512-8qRqmL9F4nuLPIgl92XUuxI3pFxize+F1H0e/W3llTk0UsjJaj01+RrirkMw7P21RKe4X6goQhYRSvNWX+70Rw==",
       "requires": {
         "mdast-squeeze-paragraphs": "^4.0.0"
+      }
+    },
+    "remark-toc": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/remark-toc/-/remark-toc-7.2.0.tgz",
+      "integrity": "sha512-ppHepvpbg7j5kPFmU5rzDC4k2GTcPDvWcxXyr/7BZzO1cBSPk0stKtEJdsgAyw2WHKPGxadcHIZRjb2/sHxjkg==",
+      "requires": {
+        "@types/unist": "^2.0.3",
+        "mdast-util-toc": "^5.0.0"
       }
     },
     "repeat-string": {

--- a/next-js/package-lock.json
+++ b/next-js/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "with-mdx",
+  "name": "andrewwestling-com",
   "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
@@ -1591,6 +1591,11 @@
         }
       }
     },
+    "emoji-regex": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.1.1.tgz",
+      "integrity": "sha1-xs0OwbBkLio8Z6ETfvxeeW2k+I4="
+    },
     "emojis-list": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
@@ -1757,6 +1762,14 @@
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
       "optional": true
+    },
+    "github-slugger": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.3.0.tgz",
+      "integrity": "sha512-gwJScWVNhFYSRDvURk/8yhcFBee6aFjye2a7Lhb2bUyRulpIoek9p0I9Kt7PT67d/nUlZbFu8L9RLiA0woQN8Q==",
+      "requires": {
+        "emoji-regex": ">=6.0.0 <=6.1.1"
+      }
     },
     "glob-parent": {
       "version": "5.1.1",
@@ -2225,6 +2238,14 @@
         "unist-util-visit": "^2.0.0"
       }
     },
+    "mdast-util-heading-range": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/mdast-util-heading-range/-/mdast-util-heading-range-2.1.5.tgz",
+      "integrity": "sha512-jXbFD0C+MfRkwsaze+btzG9CmVrxnc5kpcJLtx3SvSlPWnNdGMlDRHKDB9/TIPEq9nRHnkixppT8yvaUJ5agJg==",
+      "requires": {
+        "mdast-util-to-string": "^1.0.0"
+      }
+    },
     "mdast-util-to-hast": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-10.0.1.tgz",
@@ -2239,6 +2260,11 @@
         "unist-util-position": "^3.0.0",
         "unist-util-visit": "^2.0.0"
       }
+    },
+    "mdast-util-to-string": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-1.1.0.tgz",
+      "integrity": "sha512-jVU0Nr2B9X3MU4tSK7JP1CMkSvOj7X5l/GboG1tKRw52lLF1x2Ju92Ms9tNetCcbfX3hzlM73zYo2NKkWSfF/A=="
     },
     "mdurl": {
       "version": "1.0.1",
@@ -2896,6 +2922,24 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
       "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
     },
+    "remark-autolink-headings": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/remark-autolink-headings/-/remark-autolink-headings-6.0.1.tgz",
+      "integrity": "sha512-LTV5G5NMjypHEr14tMNJ36yrP+xwT7mejJelZOPXKiF5WvRH9o36zXnr2QGqfms2yVASNpDaC9NBOwKlJJKuQw==",
+      "requires": {
+        "extend": "^3.0.0",
+        "unist-util-visit": "^2.0.0"
+      }
+    },
+    "remark-collapse": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/remark-collapse/-/remark-collapse-0.1.2.tgz",
+      "integrity": "sha1-fr8LDgky85qFmadUkG4KCXkGBws=",
+      "requires": {
+        "mdast-util-heading-range": "^2.0.1",
+        "mdast-util-to-string": "^1.0.2"
+      }
+    },
     "remark-footnotes": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/remark-footnotes/-/remark-footnotes-2.0.0.tgz",
@@ -2944,6 +2988,16 @@
         "unist-util-remove-position": "^2.0.0",
         "vfile-location": "^3.0.0",
         "xtend": "^4.0.1"
+      }
+    },
+    "remark-slug": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/remark-slug/-/remark-slug-6.0.0.tgz",
+      "integrity": "sha512-ln67v5BrGKHpETnm6z6adlJPhESFJwfuZZ3jrmi+lKTzeZxh2tzFzUfDD4Pm2hRGOarHLuGToO86MNMZ/hA67Q==",
+      "requires": {
+        "github-slugger": "^1.0.0",
+        "mdast-util-to-string": "^1.0.0",
+        "unist-util-visit": "^2.0.0"
       }
     },
     "remark-squeeze-paragraphs": {

--- a/next-js/package.json
+++ b/next-js/package.json
@@ -14,6 +14,7 @@
     "next": "latest",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
+    "remark-collapse": "^0.1.2",
     "theme-ui": "^0.3.5"
   },
   "prettier": {

--- a/next-js/package.json
+++ b/next-js/package.json
@@ -17,6 +17,7 @@
     "remark-autolink-headings": "^6.0.1",
     "remark-collapse": "^0.1.2",
     "remark-slug": "^6.0.0",
+    "remark-toc": "^7.2.0",
     "theme-ui": "^0.3.5"
   },
   "prettier": {

--- a/next-js/package.json
+++ b/next-js/package.json
@@ -14,7 +14,9 @@
     "next": "latest",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
+    "remark-autolink-headings": "^6.0.1",
     "remark-collapse": "^0.1.2",
+    "remark-slug": "^6.0.0",
     "theme-ui": "^0.3.5"
   },
   "prettier": {

--- a/next-js/pages/media-cube.mdx
+++ b/next-js/pages/media-cube.mdx
@@ -27,6 +27,8 @@ export const updatedDate = '2021-02-21';
   </Text>
 </Message>
 
+## Table of Contents
+
 ## Overview
 
 Media Cube is a cabinet I designed and built in Spring 2013 for a furniture studio entitled _"What is a cabinet?"_ while I completed my architecture degree at [University of Oregon](https://architecture.uoregon.edu).

--- a/next-js/pages/media-cube.mdx
+++ b/next-js/pages/media-cube.mdx
@@ -27,6 +27,10 @@ export const updatedDate = '2021-02-21';
   </Text>
 </Message>
 
+## Overview
+
+Media Cube is a cabinet I designed and built in Spring 2013 for a furniture studio entitled _"What is a cabinet?"_ while I completed my architecture degree at [University of Oregon](https://architecture.uoregon.edu).
+
 <NextImage
   layout={'responsive'}
   width={800}
@@ -39,8 +43,6 @@ export const updatedDate = '2021-02-21';
   height={1200}
   src={'/assets/media-cube/media-cube.jpg'}
 />
-
-Media Cube is a cabinet I designed and built in Spring 2013 for a furniture studio entitled _"What is a cabinet?"_ while I completed my architecture degree at [University of Oregon](https://architecture.uoregon.edu).
 
 The finished piece is a 22" plywood cube that rotates and contains a collection of my most precious media objects and devices.
 

--- a/next-js/pages/resume.mdx
+++ b/next-js/pages/resume.mdx
@@ -63,7 +63,7 @@ _June 2013 — May 2014, Eugene, Oregon_
 
 Tier I technical phone support and customer service for macOS products while completing my degree. Remote position.
 
-## Tools I've used
+## Tools I use
 
 **JS/TS**: TypeScript, React, Next.js, Ember.js, Node.js, AngularJS, GraphQL, webpack
 

--- a/next-js/theme.ts
+++ b/next-js/theme.ts
@@ -115,6 +115,7 @@ export default {
         lineHeight: 1,
         paddingRight: space[1],
         marginLeft: `calc(-${space[3]} - ${space[1]})`,
+        fill: 'text',
       },
     },
     a: {

--- a/next-js/theme.ts
+++ b/next-js/theme.ts
@@ -59,6 +59,12 @@ export default {
       fontFamily: 'heading',
       lineHeight: 'heading',
       fontWeight: 'heading',
+      // For remark-autolink-headings
+      '&:hover': {
+        '.anchor-link': {
+          visibility: [null, 'visible'],
+        },
+      },
     },
     label: {
       fontSize: fontSizes[0],
@@ -101,6 +107,14 @@ export default {
       h6: {
         variant: 'text.heading',
         fontSize: [fontSizes[0], fontSizes[1]],
+      },
+      // For remark-autolink-headings
+      '.anchor-link': {
+        visibility: 'hidden',
+        float: 'left',
+        lineHeight: 1,
+        paddingRight: space[1],
+        marginLeft: `calc(-${space[3]} - ${space[1]})`,
       },
     },
     a: {


### PR DESCRIPTION
I basically ripped off GitHub's CSS and styles for how I did mine

It uses:
- `remark-slug` to generate unique IDs for each heading
- `remark-autolink-headings` to add a link element to each heading on the page
- (ripped-off CSS and SVG from how GitHub does it; yes they actually use float: left and negative margins; if it's good enough for them, it's good enough for me)
  -  I hide the anchor links on mobile, there isn't enough space in the margin to show them and you're tapping on a phone anyway so who cares)
- `remark-toc` to generate a table of contents when `## Table of contents` is added as a heading on a file

I also added `remark-collapse` to play with remark plugins at first; just gives me the collapsible `<details>` stuff that GFM has