### PR TITLE
Fix color modes

### DIFF
--- a/next-js/components/DarkModeToggle.tsx
+++ b/next-js/components/DarkModeToggle.tsx
@@ -7,6 +7,7 @@ export const DarkModeToggle = () => {
     <IconButton
       title="Toggle dark mode"
       aria-label="Toggle dark mode"
+      sx={{ '&:hover': { cursor: 'pointer' } }}
       onClick={() => {
         setColorMode(colorMode === 'default' ? 'dark' : 'default');
       }}

--- a/next-js/components/Footer.tsx
+++ b/next-js/components/Footer.tsx
@@ -1,6 +1,6 @@
 //@jsx jsx
 import NextLink from 'next/link';
-import { jsx, Box, Container, Grid, Link, SxProps, Text } from 'theme-ui';
+import { jsx, Box, Container, Grid, Link, SxProp, Text } from 'theme-ui';
 
 const socialAccounts = {
   github: {
@@ -29,7 +29,7 @@ const socialAccounts = {
   },
 };
 
-export const Footer = (props: { sx?: SxProps }) => {
+export const Footer = (props: { sx?: SxProp }) => {
   return (
     <footer sx={{ variant: 'styles.footer', ...props.sx }}>
       <Container>

--- a/next-js/components/Header.tsx
+++ b/next-js/components/Header.tsx
@@ -1,10 +1,10 @@
 //@jsx jsx
 import NextImage from 'next/image';
 import NextLink from 'next/link';
-import { jsx, Box, Container, Flex, Link, Text, SxProps } from 'theme-ui';
+import { jsx, Box, Container, Flex, Link, Text, SxProp } from 'theme-ui';
 import { DarkModeToggle } from './DarkModeToggle';
 
-export const Header = (props: { sx?: SxProps }) => (
+export const Header = (props: { sx?: SxProp }) => (
   <header
     role="banner"
     sx={{

--- a/next-js/components/Icons.tsx
+++ b/next-js/components/Icons.tsx
@@ -1,5 +1,5 @@
 export const Sun = () => (
-  <svg viewBox="0 0 24 24">
+  <svg viewBox="0 0 24 24" height="24" width="24">
     <path
       fill="currentColor"
       d="M20 15.31L23.31 12 20 8.69V4h-4.69L12 .69 8.69 4H4v4.69L.69 12 4 15.31V20h4.69L12 23.31 15.31 20H20v-4.69zM12 18V6c3.31 0 6 2.69 6 6s-2.69 6-6 6z"

--- a/next-js/package-lock.json
+++ b/next-js/package-lock.json
@@ -243,6 +243,59 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@emotion/babel-plugin": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.2.0.tgz",
+      "integrity": "sha512-lsnQBnl3l4wu/FJoyHnYRpHJeIPNkOBMbtDUIXcO8luulwRKZXPvA10zd2eXVN6dABIWNX4E34en/jkejIg/yA==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.7.0",
+        "@babel/plugin-syntax-jsx": "^7.12.1",
+        "@babel/runtime": "^7.7.2",
+        "@emotion/hash": "^0.8.0",
+        "@emotion/memoize": "^0.7.5",
+        "@emotion/serialize": "^1.0.0",
+        "babel-plugin-macros": "^2.6.1",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "^4.0.3"
+      },
+      "dependencies": {
+        "@emotion/memoize": {
+          "version": "0.7.5",
+          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.5.tgz",
+          "integrity": "sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ=="
+        },
+        "@emotion/serialize": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.0.1.tgz",
+          "integrity": "sha512-TXlKs5sgUKhFlszp/rg4lIAZd7UUSmJpwaf9/lAEFcUh2vPi32i7x4wk7O8TN8L8v2Ol8k0CxnhRBY0zQalTxA==",
+          "requires": {
+            "@emotion/hash": "^0.8.0",
+            "@emotion/memoize": "^0.7.4",
+            "@emotion/unitless": "^0.7.5",
+            "@emotion/utils": "^1.0.0",
+            "csstype": "^3.0.2"
+          }
+        },
+        "@emotion/utils": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.0.0.tgz",
+          "integrity": "sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA=="
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        },
+        "stylis": {
+          "version": "4.0.9",
+          "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.9.tgz",
+          "integrity": "sha512-ci7pEFNVW3YJiWEzqPOMsAjY6kgraZ3ZgBfQ5HYbNtLJEsQ0G46ejWZpfSSCp/FaSiCSGGhzL9O2lN+2cB6ong=="
+        }
+      }
+    },
     "@emotion/cache": {
       "version": "10.0.29",
       "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
@@ -294,6 +347,61 @@
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
       "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
+    },
+    "@emotion/react": {
+      "version": "11.1.5",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.1.5.tgz",
+      "integrity": "sha512-xfnZ9NJEv9SU9K2sxXM06lzjK245xSeHRpUh67eARBm3PBHjjKIZlfWZ7UQvD0Obvw6ZKjlC79uHrlzFYpOB/Q==",
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "@emotion/cache": "^11.1.3",
+        "@emotion/serialize": "^1.0.0",
+        "@emotion/sheet": "^1.0.1",
+        "@emotion/utils": "^1.0.0",
+        "@emotion/weak-memoize": "^0.2.5",
+        "hoist-non-react-statics": "^3.3.1"
+      },
+      "dependencies": {
+        "@emotion/cache": {
+          "version": "11.1.3",
+          "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.1.3.tgz",
+          "integrity": "sha512-n4OWinUPJVaP6fXxWZD9OUeQ0lY7DvtmtSuqtRWT0Ofo/sBLCVSgb4/Oa0Q5eFxcwablRKjUXqXtNZVyEwCAuA==",
+          "requires": {
+            "@emotion/memoize": "^0.7.4",
+            "@emotion/sheet": "^1.0.0",
+            "@emotion/utils": "^1.0.0",
+            "@emotion/weak-memoize": "^0.2.5",
+            "stylis": "^4.0.3"
+          }
+        },
+        "@emotion/serialize": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.0.1.tgz",
+          "integrity": "sha512-TXlKs5sgUKhFlszp/rg4lIAZd7UUSmJpwaf9/lAEFcUh2vPi32i7x4wk7O8TN8L8v2Ol8k0CxnhRBY0zQalTxA==",
+          "requires": {
+            "@emotion/hash": "^0.8.0",
+            "@emotion/memoize": "^0.7.4",
+            "@emotion/unitless": "^0.7.5",
+            "@emotion/utils": "^1.0.0",
+            "csstype": "^3.0.2"
+          }
+        },
+        "@emotion/sheet": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.0.1.tgz",
+          "integrity": "sha512-GbIvVMe4U+Zc+929N1V7nW6YYJtidj31lidSmdYcWozwoBIObXBnaJkKNDjZrLm9Nc0BR+ZyHNaRZxqNZbof5g=="
+        },
+        "@emotion/utils": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.0.0.tgz",
+          "integrity": "sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA=="
+        },
+        "stylis": {
+          "version": "4.0.9",
+          "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.9.tgz",
+          "integrity": "sha512-ci7pEFNVW3YJiWEzqPOMsAjY6kgraZ3ZgBfQ5HYbNtLJEsQ0G46ejWZpfSSCp/FaSiCSGGhzL9O2lN+2cB6ong=="
+        }
+      }
     },
     "@emotion/serialize": {
       "version": "0.11.16",
@@ -641,63 +749,158 @@
       }
     },
     "@theme-ui/color-modes": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@theme-ui/color-modes/-/color-modes-0.3.5.tgz",
-      "integrity": "sha512-3n5ExAnp1gAuVVFdGF2rRLyrVsa7qtmUXx+gj1wPJsADq23EE4ctkppC+aIfPFxT196WhR8fjErrVuO7Rh+wAg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@theme-ui/color-modes/-/color-modes-0.6.1.tgz",
+      "integrity": "sha512-EzI8IaX9qt/izWuv9QCQ4uTFRh4X487AN40C63amCmQ/SIRDU6KECOf0pbDBMblSjPSHAHmlSrr0L/ON7/CD/g==",
       "requires": {
-        "@emotion/core": "^10.0.0",
-        "@theme-ui/core": "0.3.5",
-        "@theme-ui/css": "0.3.5",
+        "@emotion/react": "^11.1.1",
+        "@theme-ui/core": "^0.6.1",
+        "@theme-ui/css": "0.6.0",
         "deepmerge": "^4.2.2"
       }
     },
     "@theme-ui/components": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@theme-ui/components/-/components-0.3.5.tgz",
-      "integrity": "sha512-RdWwnN43H1Tq80lGCu6icNuYCWoHHNtwH+LJGaGfiPkv/uMXWrwzKPLMiAuYM5b3ofKtmdaAcxZLjqAld97jkw==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@theme-ui/components/-/components-0.6.1.tgz",
+      "integrity": "sha512-OV12a56wdIYdis62CPn1F5JTOdaiutkvlDfXoZdivTBmRrMmg6qXSLYA8NMy5F5O1fIl5r9LfheXqv4iLUD89Q==",
       "requires": {
-        "@emotion/core": "^10.0.0",
-        "@emotion/styled": "^10.0.0",
+        "@emotion/react": "^11.1.1",
+        "@emotion/styled": "^11.0.0",
         "@styled-system/color": "^5.1.2",
         "@styled-system/should-forward-prop": "^5.1.2",
         "@styled-system/space": "^5.1.2",
-        "@theme-ui/css": "0.3.5"
+        "@theme-ui/css": "0.6.0",
+        "@types/styled-system": "^5.1.10"
+      },
+      "dependencies": {
+        "@emotion/is-prop-valid": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.1.0.tgz",
+          "integrity": "sha512-9RkilvXAufQHsSsjQ3PIzSns+pxuX4EW8EbGeSPjZMHuMx6z/MOzb9LpqNieQX4F3mre3NWS2+X3JNRHTQztUQ==",
+          "requires": {
+            "@emotion/memoize": "^0.7.4"
+          }
+        },
+        "@emotion/serialize": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.0.1.tgz",
+          "integrity": "sha512-TXlKs5sgUKhFlszp/rg4lIAZd7UUSmJpwaf9/lAEFcUh2vPi32i7x4wk7O8TN8L8v2Ol8k0CxnhRBY0zQalTxA==",
+          "requires": {
+            "@emotion/hash": "^0.8.0",
+            "@emotion/memoize": "^0.7.4",
+            "@emotion/unitless": "^0.7.5",
+            "@emotion/utils": "^1.0.0",
+            "csstype": "^3.0.2"
+          }
+        },
+        "@emotion/styled": {
+          "version": "11.1.5",
+          "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.1.5.tgz",
+          "integrity": "sha512-nIq7pOBEDqT5xSFbclQ3XFy0q8C9EUU8ECqKN2kJKGxKh+vLz/x26kEih4aOpoAsyzc+R60rQxh7VJiLTUEdmg==",
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@emotion/babel-plugin": "^11.1.2",
+            "@emotion/is-prop-valid": "^1.1.0",
+            "@emotion/serialize": "^1.0.0",
+            "@emotion/utils": "^1.0.0"
+          }
+        },
+        "@emotion/utils": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.0.0.tgz",
+          "integrity": "sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA=="
+        }
       }
     },
     "@theme-ui/core": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@theme-ui/core/-/core-0.3.5.tgz",
-      "integrity": "sha512-80gbG4BW0ZQgZ8TWSG7vY72uXDxmkI/GttjpJee7AJlWVrPh7RCD2E3cuFPjqXzt7o4BJ9lZSHmTXcLzixNtRw==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@theme-ui/core/-/core-0.6.1.tgz",
+      "integrity": "sha512-QrjEvvCEsDj2YZVB98OIYXr+kF7OzEb5CBjNAMppwAUhQYkezBDHaLnJfaaa9RODe6KAjQYHDstzg2coEmizSA==",
       "requires": {
-        "@emotion/core": "^10.0.0",
-        "@theme-ui/css": "0.3.5",
+        "@emotion/react": "^11.1.1",
+        "@theme-ui/css": "0.6.0",
+        "@theme-ui/parse-props": "^0.6.1",
         "deepmerge": "^4.2.2"
       }
     },
     "@theme-ui/css": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@theme-ui/css/-/css-0.3.5.tgz",
-      "integrity": "sha512-XqsyXmifbnHOui1flSq4V7Lb3U+06Dbn2Q/leyr/cRd6Xgc0naiztdmD0MbXNvxgU51a2Ur9hyP4PnO5wE0yRg=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@theme-ui/css/-/css-0.6.0.tgz",
+      "integrity": "sha512-+44BewW6nM4E4Fg4viutWV3y/AFxBDPgceStPoKNMWKB2h28KXFuEJIOyHse8sX39Keg/RIIcBk2q0EcDpB+LQ==",
+      "requires": {
+        "@emotion/react": "^11.1.1",
+        "csstype": "^3.0.5"
+      }
     },
     "@theme-ui/mdx": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@theme-ui/mdx/-/mdx-0.3.5.tgz",
-      "integrity": "sha512-KMf5kkEcItQ3qIj7dston/kBOZc82ST2R0pUcyk/u8ZclX4ingRtZkMxm2zpmxybzdSUY3DIKf2MTK9CxUSpOQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@theme-ui/mdx/-/mdx-0.6.1.tgz",
+      "integrity": "sha512-FGK+BAWuF2OlnSo4/4PuY4yolWCDZZl3RC9+qyLrGD8wIFrakCD2yL8g4bTatt3vfv1yRZlDlu2mq2PzANu04Q==",
       "requires": {
-        "@emotion/core": "^10.0.0",
-        "@emotion/styled": "^10.0.0",
-        "@mdx-js/react": "^1.0.0"
+        "@emotion/react": "^11.1.1",
+        "@emotion/styled": "^11.0.0",
+        "@mdx-js/react": "^1.6.22",
+        "@theme-ui/core": "^0.6.1",
+        "@theme-ui/css": "0.6.0"
+      },
+      "dependencies": {
+        "@emotion/is-prop-valid": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.1.0.tgz",
+          "integrity": "sha512-9RkilvXAufQHsSsjQ3PIzSns+pxuX4EW8EbGeSPjZMHuMx6z/MOzb9LpqNieQX4F3mre3NWS2+X3JNRHTQztUQ==",
+          "requires": {
+            "@emotion/memoize": "^0.7.4"
+          }
+        },
+        "@emotion/serialize": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.0.1.tgz",
+          "integrity": "sha512-TXlKs5sgUKhFlszp/rg4lIAZd7UUSmJpwaf9/lAEFcUh2vPi32i7x4wk7O8TN8L8v2Ol8k0CxnhRBY0zQalTxA==",
+          "requires": {
+            "@emotion/hash": "^0.8.0",
+            "@emotion/memoize": "^0.7.4",
+            "@emotion/unitless": "^0.7.5",
+            "@emotion/utils": "^1.0.0",
+            "csstype": "^3.0.2"
+          }
+        },
+        "@emotion/styled": {
+          "version": "11.1.5",
+          "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.1.5.tgz",
+          "integrity": "sha512-nIq7pOBEDqT5xSFbclQ3XFy0q8C9EUU8ECqKN2kJKGxKh+vLz/x26kEih4aOpoAsyzc+R60rQxh7VJiLTUEdmg==",
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@emotion/babel-plugin": "^11.1.2",
+            "@emotion/is-prop-valid": "^1.1.0",
+            "@emotion/serialize": "^1.0.0",
+            "@emotion/utils": "^1.0.0"
+          }
+        },
+        "@emotion/utils": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.0.0.tgz",
+          "integrity": "sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA=="
+        }
+      }
+    },
+    "@theme-ui/parse-props": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@theme-ui/parse-props/-/parse-props-0.6.1.tgz",
+      "integrity": "sha512-7bnKDxwEZIfEyreEvdg1etnPFsR4NH1gW67LpjRgpmrosKWD4F5IsAGPQMThMDsKuvJclViz4zXMP76MbkI6rw==",
+      "requires": {
+        "@emotion/react": "^11.1.1",
+        "@theme-ui/css": "0.6.0"
       }
     },
     "@theme-ui/theme-provider": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@theme-ui/theme-provider/-/theme-provider-0.3.5.tgz",
-      "integrity": "sha512-C1kVsGyrh/pqO/j4+KSF5IvVW1DOnZoQmpaJ9EjyU4bqY0PCTZfuNdNPfydKaDWiYxrKGXKBeX0xjvLLU6R0zQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@theme-ui/theme-provider/-/theme-provider-0.6.1.tgz",
+      "integrity": "sha512-qtuUDB4IXLcIWwHyNXf1XTqFo91p1NtBM3bH9z2W4agYM6S9e9XMjYhfnUo02AT6iEbJeHUppQ8H8H71yt2qVg==",
       "requires": {
-        "@emotion/core": "^10.0.0",
-        "@theme-ui/color-modes": "0.3.5",
-        "@theme-ui/core": "0.3.5",
-        "@theme-ui/mdx": "0.3.5"
+        "@emotion/react": "^11.1.1",
+        "@theme-ui/color-modes": "^0.6.1",
+        "@theme-ui/core": "^0.6.1",
+        "@theme-ui/mdx": "^0.6.1"
       }
     },
     "@types/hast": {
@@ -1918,6 +2121,14 @@
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
       }
     },
     "html-void-elements": {
@@ -3465,16 +3676,16 @@
       }
     },
     "theme-ui": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/theme-ui/-/theme-ui-0.3.5.tgz",
-      "integrity": "sha512-yxooGhvkdjFDotDeIFehKo5k6NnLZ3gsLSe8EDe2aDcoWqg1mZjkjjr8EYtVCrK3mk/tYz97AT5BpEnUfamNCQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/theme-ui/-/theme-ui-0.6.1.tgz",
+      "integrity": "sha512-SpbXjBAP6eoXcZaENxtAlxYw4XcrLS8/3Jzpb4b8kXBKQ+6BqSRH9w7rcyHfWXaebEpnNm4pUQt+Qce5j0OTxA==",
       "requires": {
-        "@theme-ui/color-modes": "0.3.5",
-        "@theme-ui/components": "0.3.5",
-        "@theme-ui/core": "0.3.5",
-        "@theme-ui/css": "0.3.5",
-        "@theme-ui/mdx": "0.3.5",
-        "@theme-ui/theme-provider": "0.3.5"
+        "@theme-ui/color-modes": "^0.6.1",
+        "@theme-ui/components": "^0.6.1",
+        "@theme-ui/core": "^0.6.1",
+        "@theme-ui/css": "0.6.0",
+        "@theme-ui/mdx": "^0.6.1",
+        "@theme-ui/theme-provider": "^0.6.1"
       }
     },
     "timers-browserify": {

--- a/next-js/package.json
+++ b/next-js/package.json
@@ -18,7 +18,7 @@
     "remark-collapse": "^0.1.2",
     "remark-slug": "^6.0.0",
     "remark-toc": "^7.2.0",
-    "theme-ui": "^0.3.5"
+    "theme-ui": "^0.6.1"
   },
   "prettier": {
     "printWidth": 80,

--- a/next-js/pages/_app.tsx
+++ b/next-js/pages/_app.tsx
@@ -1,13 +1,10 @@
 // @jsx jsx
 import NextApp from 'next/app';
 import Head from 'next/head';
-import NextImage from 'next/image';
-import NextLink from 'next/link';
 import * as React from 'react';
-import { jsx, Box, Container, Flex, Link, Text, ThemeProvider } from 'theme-ui';
-import { DarkModeToggle } from '../components/DarkModeToggle';
-import { Header } from '../components/Header';
+import { jsx, Container, Flex, ThemeProvider } from 'theme-ui';
 import { Footer } from '../components/Footer';
+import { Header } from '../components/Header';
 import theme from '../theme';
 
 export default class App extends NextApp {

--- a/next-js/pages/awds.mdx
+++ b/next-js/pages/awds.mdx
@@ -57,8 +57,10 @@ export const Colors = () => {
             }}
           />
           <Box>
-            <Text>{color}</Text>
-            <Text variant="label">{theme.colors[color]}</Text>
+            <Text as="div">{color}</Text>
+            <Text as="div" variant="label">
+              {theme.rawColors[color]}
+            </Text>
           </Box>
         </Grid>
       ))}

--- a/next-js/theme.ts
+++ b/next-js/theme.ts
@@ -1,3 +1,5 @@
+import { Z_BLOCK } from 'node:zlib';
+
 const fontSizes = [
   '0.800rem',
   '1.000rem',
@@ -72,6 +74,7 @@ export default {
     footer: {
       lineHeight: 2,
       fontSize: fontSizes[0],
+      display: 'block',
     },
     default: {
       fontSize: fontSizes[1],

--- a/next-js/theme.ts
+++ b/next-js/theme.ts
@@ -21,6 +21,7 @@ const space = [
 
 export default {
   useColorSchemeMediaQuery: true,
+  useLocalStorage: false,
   breakpoints: ['40rem'],
   fonts: {
     body: 'system-ui, sans-serif',

--- a/next-js/theme.ts
+++ b/next-js/theme.ts
@@ -1,4 +1,4 @@
-import { Z_BLOCK } from 'node:zlib';
+import { Theme } from 'theme-ui';
 
 const fontSizes = [
   '0.800rem',
@@ -19,7 +19,7 @@ const space = [
   '8.000rem',
 ];
 
-export default {
+const theme: Theme = {
   useColorSchemeMediaQuery: true,
   useLocalStorage: false,
   breakpoints: ['40rem'],
@@ -164,3 +164,5 @@ export default {
     },
   },
 };
+
+export default theme;


### PR DESCRIPTION
Theme UI color modes had some issues that I noticed after using my site for a bit:
- Safari on both iOS and macOS (and any browser on iOS because WebView) were not showing the SVG in the toggle button
- I was using the local storage feature which was causing Theme UI to default to the saved entry in local storage for selected color mode rather than use the system's current setting (example is if I first went to the website in daytime then Theme UI set the local storage value to "light mode," then I came back at night and my phone went into dark mode, Theme UI would still read the local storage entry saying "light mode" and set that instead of obeying the system's setting, which is now dark mode)
- There was a flash of light mode before dark mode

I managed to fix all of it:
- Safari needs `height=` and `width=` attributes on SVGs (https://stackoverflow.com/a/27249490) (806f283)
- There is a setting to turn off local storage for Theme UI (6b7f06f)
- I updated Theme UI version and it fixed the flash of the wrong color mode; there were also some breaking changes that I fixed with that (e894675)